### PR TITLE
Fix bug caused by typo in nodes/Topologic/VertexEnclosingCell.py

### DIFF
--- a/nodes/Topologic/VertexEnclosingCell.py
+++ b/nodes/Topologic/VertexEnclosingCell.py
@@ -84,7 +84,7 @@ class SvVertexEnclosingCell(bpy.types.Node, SverchCustomTreeNode):
 		if not any(socket.is_linked for socket in self.outputs):
 			return
 		if not any(socket.is_linked for socket in self.inputs):
-			for anOutput in self.ouputs:
+			for anOutput in self.outputs:
 				anOutput.sv_set([])
 			return
 		inputs_nested = []


### PR DESCRIPTION
This looks like a bug. Hasn't been tested. Please review.