### PR TITLE
Fix bug cause by typo in nodes/Topologic/GraphToDGL.py

### DIFF
--- a/nodes/Topologic/GraphToDGL.py
+++ b/nodes/Topologic/GraphToDGL.py
@@ -32,7 +32,7 @@ def processItem(graph, tolerance):
 	for aVertex in vertices:
 		vdict = aVertex.GetDictionary()
 		label = vdict['ID'
-		lables.append([label])
+		labels.append([label])
 	edges = []
 	_ = graph.Edges(vertices, tolerance, edges)
 	startVertices = []


### PR DESCRIPTION
This looks like a bug. Hasn't been tested. Please review.