### PR TITLE
Fix documentation and source comment typos

### DIFF
--- a/nodes/Topologic/DGLOptimizer.py
+++ b/nodes/Topologic/DGLOptimizer.py
@@ -74,7 +74,7 @@ class SvDGLOptimizer(bpy.types.Node, SverchCustomTreeNode):
 	bl_idname = 'SvDGLOptimizer'
 	bl_label = 'DGL.Optimizer'
 	Replication: EnumProperty(name="Replication", description="Replication", default="Default", items=replication, update=updateNode)
-	Optimizers: EnumProperty(name="Optimizer", description="This will be the selected optimizer from the torch.optim package. The defaul is Adam", default="Adam", items=optimizers, update=update_sockets)
+	Optimizers: EnumProperty(name="Optimizer", description="This will be the selected optimizer from the torch.optim package. The default is Adam", default="Adam", items=optimizers, update=update_sockets)
 
 	Adadelta_epsProp: FloatProperty(name="eps", description="term added to the denominator to improve numerical stability (default: 1e-6)", default=0.000001, precision=6, update=updateNode)
 	Adadelta_lrProp: FloatProperty(name="lr", description="coefficient that scale delta before it is applied to the parameters (default: 1.0)", default=1.0, precision=6, update=updateNode)

--- a/nodes/Topologic/EnergyModelDefaultConstructionSets.py
+++ b/nodes/Topologic/EnergyModelDefaultConstructionSets.py
@@ -29,7 +29,7 @@ def processItem(item):
 class SvEnergyModelDefaultConstructionSets(bpy.types.Node, SverchCustomTreeNode):
 	"""
 	Triggers: Topologic
-	Tooltip: Returns the Defaul Construction Sets found in the input Energy Model
+	Tooltip: Returns the Default Construction Sets found in the input Energy Model
 	"""
 	bl_idname = 'SvEnergyModelDefaultConstructionSets'
 	bl_label = 'EnergyModel.DefaultConstructionSets'

--- a/nodes/Topologic/EnergyModelDefaultScheduleSets.py
+++ b/nodes/Topologic/EnergyModelDefaultScheduleSets.py
@@ -29,7 +29,7 @@ def processItem(item):
 class SvEnergyModelDefaultScheduleSets(bpy.types.Node, SverchCustomTreeNode):
 	"""
 	Triggers: Topologic
-	Tooltip: Returns the Defaul Schedule Sets found in the input Energy Model
+	Tooltip: Returns the Default Schedule Sets found in the input Energy Model
 	"""
 	bl_idname = 'SvEnergyModelDefaultScheduleSets'
 	bl_label = 'EnergyModel.DefaultScheduleSets'

--- a/nodes/Topologic/GraphMST.py
+++ b/nodes/Topologic/GraphMST.py
@@ -80,7 +80,7 @@ class Graph:
 			x = self.find(parent, u) 
 			y = self.find(parent ,v) 
 
-			# If including this edge does't cause cycle, 
+			# If including this edge doesn't cause cycle, 
 						# include it in result and increment the index 
 						# of result for next edge 
 			if x != y: 

--- a/nodes/Topologic/WireCycles.py
+++ b/nodes/Topologic/WireCycles.py
@@ -135,7 +135,7 @@ replication = [("Default", "Default", "", 1),("Trim", "Trim", "", 2),("Iterate",
 class SvWireCycles(bpy.types.Node, SverchCustomTreeNode):
 	"""
 	Triggers: Topologic
-	Tooltip: Outputs the closed cycles (Wires) with the maximum number of input Vertices found in the inut Wire    
+	Tooltip: Outputs the closed cycles (Wires) with the maximum number of input Vertices found in the input Wire    
 	"""
 	bl_idname = 'SvWireCycles'
 	bl_label = 'Wire.Cycles'


### PR DESCRIPTION
Found via `codespell -q 3 -L doas,mata,warmup`